### PR TITLE
Fix signWithWSSEInfo concurrency problem

### DIFF
--- a/envelope.go
+++ b/envelope.go
@@ -72,18 +72,18 @@ func (e *Envelope) signWithWSSEInfo(info *WSSEAuthInfo) error {
 
 	e.Body.XMLNSWsu = wsuNS
 
-	err := info.generateIDs()
+	ids, err := generateWSSEAuthIds()
 	if err != nil {
 		return err
 	}
 
-	securityHeader, err := info.sign(*e.Body)
+	securityHeader, err := info.sign(*e.Body, ids)
 	if err != nil {
 		return err
 	}
 
 	e.AddHeaders(securityHeader)
-	e.Body.ID = info.bodyID
+	e.Body.ID = ids.bodyID
 
 	return nil
 }

--- a/envelope.go
+++ b/envelope.go
@@ -72,7 +72,7 @@ func (e *Envelope) signWithWSSEInfo(info *WSSEAuthInfo) error {
 
 	e.Body.XMLNSWsu = wsuNS
 
-	ids, err := generateWSSEAuthIds()
+	ids, err := generateWSSEAuthIDs()
 	if err != nil {
 		return err
 	}

--- a/wsse.go
+++ b/wsse.go
@@ -36,7 +36,10 @@ const (
 type WSSEAuthInfo struct {
 	certDER string
 	key     *rsa.PrivateKey
+}
 
+// WSSEAuthIds contains generated IDs used in WS-Security X.509 signing.
+type WSSEAuthIds struct {
 	securityTokenID string
 	bodyID          string
 }
@@ -180,7 +183,7 @@ type security struct {
 	Signature           signature
 }
 
-func (w *WSSEAuthInfo) generateToken() ([]byte, error) {
+func (w *WSSEAuthIds) generateToken() ([]byte, error) {
 	// We use a concatentation of the time and 10 securely generated random numbers to be the tokens.
 	b := make([]byte, 10)
 
@@ -198,26 +201,28 @@ func (w *WSSEAuthInfo) generateToken() ([]byte, error) {
 	return tokenHex, nil
 }
 
-func (w *WSSEAuthInfo) generateIDs() error {
+func generateWSSEAuthIds() (*WSSEAuthIds, error) {
+	w := &WSSEAuthIds{}
+
 	securityTokenHex, err := w.generateToken()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	w.securityTokenID = fmt.Sprintf("SecurityToken-%x", securityTokenHex)
 
 	bodyTokenHex, err := w.generateToken()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	w.bodyID = fmt.Sprintf("Body-%x", bodyTokenHex)
-	return nil
+	return w, nil
 }
 
-func (w *WSSEAuthInfo) sign(body Body) (security, error) {
+func (w *WSSEAuthInfo) sign(body Body, ids *WSSEAuthIds) (security, error) {
 	// 0. We create the body_id and security_token_id values
-	body.ID = w.bodyID
+	body.ID = ids.bodyID
 
 	// 1. We create the DigestValue of the body.
 
@@ -247,7 +252,7 @@ func (w *WSSEAuthInfo) sign(body Body) (security, error) {
 			Algorithm: rsaSha1Sig,
 		},
 		Reference: signatureReference{
-			URI: "#" + w.bodyID,
+			URI: "#" + ids.bodyID,
 			Transforms: transforms{
 				Transform: transform{
 					Algorithm: canonicalizationExclusiveC14N,
@@ -282,7 +287,7 @@ func (w *WSSEAuthInfo) sign(body Body) (security, error) {
 		XMLNS: wsseNS,
 		BinarySecurityToken: binarySecurityToken{
 			XMLNS:        wsuNS,
-			WsuID:        w.securityTokenID,
+			WsuID:        ids.securityTokenID,
 			EncodingType: encTypeBinary,
 			ValueType:    valTypeX509Token,
 			Value:        w.certDER,
@@ -296,7 +301,7 @@ func (w *WSSEAuthInfo) sign(body Body) (security, error) {
 					XMLNS: wsuNS,
 					Reference: strReference{
 						ValueType: valTypeX509Token,
-						URI:       "#" + w.securityTokenID,
+						URI:       "#" + ids.securityTokenID,
 					},
 				},
 			},

--- a/wsse.go
+++ b/wsse.go
@@ -38,8 +38,8 @@ type WSSEAuthInfo struct {
 	key     *rsa.PrivateKey
 }
 
-// WSSEAuthIds contains generated IDs used in WS-Security X.509 signing.
-type WSSEAuthIds struct {
+// WSSEAuthIDs contains generated IDs used in WS-Security X.509 signing.
+type WSSEAuthIDs struct {
 	securityTokenID string
 	bodyID          string
 }
@@ -183,7 +183,7 @@ type security struct {
 	Signature           signature
 }
 
-func (w *WSSEAuthIds) generateToken() ([]byte, error) {
+func (w *WSSEAuthIDs) generateToken() ([]byte, error) {
 	// We use a concatentation of the time and 10 securely generated random numbers to be the tokens.
 	b := make([]byte, 10)
 
@@ -201,8 +201,8 @@ func (w *WSSEAuthIds) generateToken() ([]byte, error) {
 	return tokenHex, nil
 }
 
-func generateWSSEAuthIds() (*WSSEAuthIds, error) {
-	w := &WSSEAuthIds{}
+func generateWSSEAuthIDs() (*WSSEAuthIDs, error) {
+	w := &WSSEAuthIDs{}
 
 	securityTokenHex, err := w.generateToken()
 	if err != nil {
@@ -220,7 +220,7 @@ func generateWSSEAuthIds() (*WSSEAuthIds, error) {
 	return w, nil
 }
 
-func (w *WSSEAuthInfo) sign(body Body, ids *WSSEAuthIds) (security, error) {
+func (w *WSSEAuthInfo) sign(body Body, ids *WSSEAuthIDs) (security, error) {
 	// 0. We create the body_id and security_token_id values
 	body.ID = ids.bodyID
 


### PR DESCRIPTION
When signWithWSSEInfo is passed the same WSSEAuthInfo object
on different threads, it's possible for the ID fields to change
while the sign method is executing resulting in a payload that
isn't signed correctly.

This change splits out the generated IDs from WSSEAuthInfo into
their own var so that they aren't part of the state shared
between calls.